### PR TITLE
fix: linux arm64 wheels should not be overwritten

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           path: wheelhouse/*.whl
-          name: python-package-distributions
+          name: python-package-distributions-${{ matrix.os }}-${{ matrix.arch }}
           overwrite: true
   publish-to-pypi:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -195,7 +195,8 @@ jobs:
         - name: Download all the dists
           uses: actions/download-artifact@v4
           with:
-            name: python-package-distributions
+            pattern: python-package-distributions-*
             path: dist/
+            merge-multiple: true
         - name: Publish distribution 📦 to PyPI
           uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Linux was already there, but it was getting overwritten by x86.